### PR TITLE
Fix build for rust stable 1.29

### DIFF
--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["polyfractal <zach@zacharytong.com>"]
 
 [dependencies]
 # New version that fixes compilation:
-freertos_rs = { git = "https://github.com/hashmismatch/freertos.rs", rev = "7bc71903e96c0bc395aa7473b95d5fb0e5499175" }
+freertos_rs = { git = "https://github.com/hashmismatch/freertos.rs", rev = "f056dcbb357597aa7c8f603b8b7e57c3f7e02a4c" }
 
 # the profile used for `cargo build`
 [profile.dev]

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -1,6 +1,5 @@
 #![no_std]
 #![feature(alloc)]
-#![feature(collections)]
 #![feature(lang_items)]
 
 #[lang = "eh_personality"] extern fn eh_personality() {}


### PR DESCRIPTION
I basically ran into [this issue](https://github.com/hashmismatch/freertos.rs/issues/18) when compiling with the rust stable 1.28+ (could also affect e.g. 1.27 not sure where the breaking change come in).
[The fix](https://github.com/hashmismatch/freertos.rs/commit/f056dcbb357597aa7c8f603b8b7e57c3f7e02a4c) for freertos is not yet merged to freertos/master.
Furthermore I ran into prior to removing it:
```
error[E0635]: unknown feature `collections`                                                                                                                                                                                                                                                
 --> src/lib.rs:3:12                                                                                                                                                                                                                                                                       
  |                                                                                                                                                                                                                                                                                        
3 | #![feature(collections)]                                                                                                                                                                                                                                                               
  |            ^^^^^^^^^^^       
```
 